### PR TITLE
Switch to using per-broker rand source

### DIFF
--- a/pkg/landgrab/attacking.go
+++ b/pkg/landgrab/attacking.go
@@ -14,16 +14,16 @@ func min(a, b int) int {
 	return b
 }
 
-func roll(numDice int) []int {
+func roll(numDice int, r *rand.Rand) []int {
 	ret := make([]int, numDice)
 	for i := 0; i < numDice; i++ {
-		ret[i] = rand.Intn(diceSides) + 1
+		ret[i] = r.Intn(diceSides) + 1
 	}
 	sort.Sort(sort.Reverse(sort.IntSlice(ret)))
 	return ret
 }
 
-func oneRound(attackers, defenders, dice int) (int, int) {
+func oneRound(attackers, defenders, dice int, r *rand.Rand) (int, int) {
 	if dice > attackers {
 		dice = attackers
 	}
@@ -32,8 +32,8 @@ func oneRound(attackers, defenders, dice int) (int, int) {
 
 	matchups := min(attackerDice, defenderDice)
 
-	attackerRoll := roll(attackerDice)
-	defenderRoll := roll(defenderDice)
+	attackerRoll := roll(attackerDice, r)
+	defenderRoll := roll(defenderDice, r)
 
 	for i := 0; i < matchups; i++ {
 		if attackerRoll[i] > defenderRoll[i] {
@@ -46,10 +46,10 @@ func oneRound(attackers, defenders, dice int) (int, int) {
 }
 
 // Attack with as much as you ahve until it's either taken or you can't attack
-func invade(attackers, defenders int) (int, int, bool) {
+func invade(attackers, defenders int, r *rand.Rand) (int, int, bool) {
 
 	for attackers > 1 && defenders > 0 {
-		attackers, defenders = oneRound(attackers, defenders, 3)
+		attackers, defenders = oneRound(attackers, defenders, 3, r)
 	}
 	if defenders == 0 {
 		return 1, attackers - 1, true
@@ -59,9 +59,9 @@ func invade(attackers, defenders int) (int, int, bool) {
 
 // Given an attacking territory w attackers, invade one territory after another
 // Return how many attacking armies are in the last territory, or 0 if you never get there
-func campaign(attackers int, defenderingTerritories []int) int {
+func campaign(attackers int, defenderingTerritories []int, r *rand.Rand) int {
 	for i := 0; i < len(defenderingTerritories); i++ {
-		_, newAttackers, success := invade(attackers, defenderingTerritories[i])
+		_, newAttackers, success := invade(attackers, defenderingTerritories[i], r)
 		//fmt.Printf("Invading %d->%d leaves %d in defending w success %v\n", attackers, defenderingTerritories[i], newAttackers, success)
 		attackers = newAttackers
 		if !success {


### PR DESCRIPTION
Based on some tests, results seem to be the same but between 2 and 4 times faster

| Input   | Shared Rand | Shared Rand result       | Per-broker Rand | Per-Broker result        | Speedup |
|---------|-------------|--------------------------|-----------------|--------------------------|---------|
| 10      | 1.16s       | 32 with avg 23 remaining | 242ms           | 33 with avg 24 remaining | 4.7x |
| 30      | 15s         | 62 with avg 36 remaining | 3.6s            | 64 with avg 38 remaining | 4.2x |
| 1x10    | 488ms       | 27 with avg 12 remaining | 73ms            | 27 with avg 12 remaining | 2.1x |
| 10x5    | 51s         | 91 with avg 45 remaining | 11s             | 91 with avg 45 remaining | 4.6x |