### PR TITLE
Remove logically uneeded code

### DIFF
--- a/pkg/landgrab/attacking.go
+++ b/pkg/landgrab/attacking.go
@@ -32,9 +32,6 @@ func roll(numDice int, r *rand.Rand) []int {
 // Simulate a single click of the "attack" button
 func oneRound(attackers, defenders, dice int, r *rand.Rand) (int, int) {
 	// Can only attack with as many attackers as are present
-	if dice > attackers {
-		dice = attackers
-	}
 	attackerDice := min(dice, attackers)
 	defenderDice := min(2, defenders)
 


### PR DESCRIPTION
The next line runs a "min" of these two values, so setting one to the other if it's larger is redundant.

I confirmed this by running the code deterministically (one thread, hard-coded rand seed) and saw identical results.